### PR TITLE
WP-7721 use role as an optional parameter when setting up a snowflake connection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-snowflake',
-      version='2.0.4',
+      version='2.0.5',
       description='Singer.io tap for extracting data from Snowflake - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_snowflake/connection.py
+++ b/tap_snowflake/connection.py
@@ -70,6 +70,7 @@ class SnowflakeConnection:
             user=self.connection_config['user'],
             password=self.connection_config['password'],
             account=self.connection_config['account'],
+            role=self.connection_config.get('role'),  # optional parameter
             database=self.connection_config['dbname'],
             warehouse=self.connection_config['warehouse'],
             insecure_mode=self.connection_config.get('insecure_mode', False)


### PR DESCRIPTION
some snowflake accounts require the use of a role, this change allows us to pass it in as part of the config json file

this change is required in order for us to use the shared Symon snowflake account in sanity and other testing

https://varicent.atlassian.net/browse/WP-7721