### PR TITLE
WP-9018 maintain column order

### DIFF
--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -286,7 +286,7 @@ def desired_columns(selected, table_schema):
             'Columns %s are primary keys but were not selected. Adding them.',
             not_selected_but_automatic)
 
-    return selected.intersection(available).union(automatic)
+    return sorted(selected.intersection(available).union(automatic), key = list(table_schema.properties.keys()).index)
 
 
 def resolve_catalog(discovered_catalog, streams_to_sync):


### PR DESCRIPTION
## Problem
Import doesn't maintain original columns' order and the columns' order changed on different runs, which causing issues for refreshing and creating app via recommendation.
Jira: https://varicent.atlassian.net/browse/WP-9018
## Proposed changes
using the schema order to maintain the column order
will create tag v2.0.6