### PR TITLE
Wp 7637: support Semi-structured  and geography datatype 

### DIFF
--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -58,6 +58,7 @@ INTEGER_TYPES = set(['int', 'integer', 'bigint', 'smallint'])
 FLOAT_TYPES = set(['float', 'float4', 'float8', 'real', 'double', 'double precision'])
 DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
 BINARY_TYPE = set(['binary', 'varbinary'])
+IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
 
 
 def schema_for_column(c):
@@ -94,6 +95,12 @@ def schema_for_column(c):
     elif data_type in BINARY_TYPE:
         result.type = ['null', 'string']
         result.format = 'binary'
+    #todo
+    elif data_type in IDENTIFIED_UNSUPPORT_TYPES:
+        result = Schema(None,
+                        inclusion='unsupported',
+                        description='Unsupported data type {}'.format(data_type))
+        result.type = ['null', 'string'] 
 
     else:
         result = Schema(None,
@@ -111,6 +118,7 @@ def create_column_metadata(cols):
                                ('properties', c.column_name),
                                'selected-by-default',
                                schema.inclusion != 'unsupported')
+                            #    todo
         mdata = metadata.write(mdata,
                                ('properties', c.column_name),
                                'sql-datatype',
@@ -264,7 +272,7 @@ def desired_columns(selected, table_schema):
         elif inclusion == 'available':
             available.add(column)
         elif inclusion == 'unsupported':
-            unsupported.add(column)
+            available.add(column)
         else:
             raise Exception('Unknown inclusion ' + inclusion)
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -58,7 +58,8 @@ INTEGER_TYPES = set(['int', 'integer', 'bigint', 'smallint'])
 FLOAT_TYPES = set(['float', 'float4', 'float8', 'real', 'double', 'double precision'])
 DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
 BINARY_TYPE = set(['binary', 'varbinary'])
-IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
+IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array'])
+# IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
 
 
 def schema_for_column(c):
@@ -95,11 +96,9 @@ def schema_for_column(c):
     elif data_type in BINARY_TYPE:
         result.type = ['null', 'string']
         result.format = 'binary'
-    #todo
+        
     elif data_type in IDENTIFIED_UNSUPPORT_TYPES:
-        result = Schema(None,
-                        inclusion='unsupported',
-                        description='Unsupported data type {}'.format(data_type))
+        result = Schema(inclusion='unsupported')
         result.type = ['null', 'string'] 
 
     else:
@@ -118,7 +117,6 @@ def create_column_metadata(cols):
                                ('properties', c.column_name),
                                'selected-by-default',
                                schema.inclusion != 'unsupported')
-                            #    todo
         mdata = metadata.write(mdata,
                                ('properties', c.column_name),
                                'sql-datatype',
@@ -293,7 +291,7 @@ def desired_columns(selected, table_schema):
         LOGGER.warning(
             'Columns %s are primary keys but were not selected. Adding them.',
             not_selected_but_automatic)
-
+    # may adding union(unsupported) to inlude unsupported columns for import
     return sorted(selected.intersection(available).union(automatic), key = list(table_schema.properties.keys()).index)
 
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -272,7 +272,7 @@ def desired_columns(selected, table_schema):
         elif inclusion == 'available':
             available.add(column)
         elif inclusion == 'unsupported':
-            available.add(column)
+            unsupported.add(column)
         else:
             raise Exception('Unknown inclusion ' + inclusion)
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -58,8 +58,7 @@ INTEGER_TYPES = set(['int', 'integer', 'bigint', 'smallint'])
 FLOAT_TYPES = set(['float', 'float4', 'float8', 'real', 'double', 'double precision'])
 DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
 BINARY_TYPE = set(['binary', 'varbinary'])
-IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array'])
-# IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
+IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
 
 
 def schema_for_column(c):
@@ -291,7 +290,7 @@ def desired_columns(selected, table_schema):
         LOGGER.warning(
             'Columns %s are primary keys but were not selected. Adding them.',
             not_selected_but_automatic)
-    # may adding union(unsupported) to inlude unsupported columns for import
+            
     return sorted(selected.intersection(available).union(automatic), key = list(table_schema.properties.keys()).index)
 
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -97,7 +97,6 @@ def schema_for_column(c):
         result.format = 'binary'
         
     elif data_type in IDENTIFIED_UNSUPPORT_TYPES:
-        result = Schema(inclusion='unsupported')
         result.type = ['null', 'string'] 
 
     else:

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -58,8 +58,8 @@ INTEGER_TYPES = set(['int', 'integer', 'bigint', 'smallint'])
 FLOAT_TYPES = set(['float', 'float4', 'float8', 'real', 'double', 'double precision'])
 DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
 BINARY_TYPE = set(['binary', 'varbinary'])
-IDENTIFIED_UNSUPPORT_TYPES = set(['variant', 'object', 'array', 'geography'])
-
+SEMI_STRUCTURED_TYPES = set(['variant', 'object', 'array'])
+GEOGRAPHY_TYPE =set(['geography'])
 
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
@@ -96,8 +96,13 @@ def schema_for_column(c):
         result.type = ['null', 'string']
         result.format = 'binary'
         
-    elif data_type in IDENTIFIED_UNSUPPORT_TYPES:
+    elif data_type in SEMI_STRUCTURED_TYPES:
         result.type = ['null', 'string'] 
+        result.format = 'semi_structured'
+
+    elif data_type in GEOGRAPHY_TYPE:
+        result.type = ['null', 'string'] 
+        result.format = 'geography'
 
     else:
         result = Schema(None,

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -99,13 +99,17 @@ def generate_select_sql(catalog_entry, columns):
 
     for col_name in columns:
         escaped_col = escape(col_name)
-
+        
         # fetch the column type format from the json schema alreay built
         property_format = catalog_entry.schema.properties[col_name].format
 
         # if the column format is binary, fetch the hexified value
         if property_format == 'binary':
             escaped_columns.append(f'hex_encode({escaped_col}) as {escaped_col}')
+        elif property_format == 'semi_structured':
+            escaped_columns.append(f'TO_VARCHAR({escaped_col}) as {escaped_col}')
+        elif property_format == 'geography':
+            escaped_columns.append(f'ST_ASTEXT({escaped_col}) as {escaped_col}')
         else:
             escaped_columns.append(escaped_col)
 


### PR DESCRIPTION
## Problem
Jira: https://varicent.atlassian.net/browse/WP-7557 and https://varicent.atlassian.net/browse/WP-7637
Semi-structured datatypes(array, object, variant) and geography datatype were not supported, so their inclusion were set as unsupported.

## Proposed changes

cast Semi-structured datatypes to VARCHAR and geography datatype to TEXT and cast them to string. Change their inclusion to be available.

## Proposed tag
v2.0.7
