### PR TITLE
Bump snowflake-connector-python to 2.7.* (from 2.4.*)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-snowflake',
-      version='2.0.7',
+      version='2.0.8',
       description='Singer.io tap for extracting data from Snowflake - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -19,7 +19,7 @@ setup(name='pipelinewise-tap-snowflake',
       py_modules=['tap_snowflake'],
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'snowflake-connector-python[pandas]==2.4.*',
+          'snowflake-connector-python[pandas]==2.7.*',
           'pendulum==1.2.0',
           'setuptools>=40.8.0',
           'wheel>=0.37.0',

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -507,3 +507,5 @@ def main():
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc
+if __name__ == '__main__':
+    main()

--- a/tap_snowflake/connection.py
+++ b/tap_snowflake/connection.py
@@ -73,6 +73,7 @@ class SnowflakeConnection:
             role=self.connection_config.get('role'),  # optional parameter
             database=self.connection_config['dbname'],
             warehouse=self.connection_config['warehouse'],
+            client_prefetch_threads=self.connection_config.get('client_prefetch_threads', 4),
             insecure_mode=self.connection_config.get('insecure_mode', False)
             # Use insecure mode to avoid "Failed to get OCSP response" warnings
             # insecure_mode=True


### PR DESCRIPTION
Bump snowflake-connector-python to 2.7.* (from 2.4.*)
Added *optional* config parameter (client_prefetch_threads)
Enabled running the Tap in a debugger