### PR TITLE
Bumped version of pipelinewise-singer-python.  Made several optimizations based on profiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-snowflake',
       ],
       py_modules=['tap_snowflake'],
       install_requires=[
-          'pipelinewise-singer-python==1.*',
+          'pipelinewise-singer-python==2.0.1',
           'snowflake-connector-python[pandas]==2.7.*',
           'pendulum==1.2.0',
           'setuptools>=40.8.0',

--- a/tests/integration/test_tap_snowflake.py
+++ b/tests/integration/test_tap_snowflake.py
@@ -249,7 +249,7 @@ class TestTypeMapping(unittest.TestCase):
                 row = cur.fetchone()
 
                 # Convert the exported data to singer JSON
-                record_message = common.row_to_singer_record(catalog_entry=catalog_entry,
+                record_message = common.row_to_singer_record2(catalog_entry=catalog_entry,
                                                              version=1,
                                                              row=row,
                                                              columns=columns,


### PR DESCRIPTION
Bumped version of pipelinewise-singer-python to take advantage of faster json serialization

Added 'profile_execution' config parameter that enables profiling on Sync only
4 optimizations based on profiling
- 2 million rows went from over 200 seconds down to 110 seconds
