### PR TITLE
WP-12820 Snowflake data import failing with DECIMAL (2,1) datatype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipelinewise-tap-snowflake"
-version = "2.0.9"
+version = "2.0.10"
 description = "Singer.io tap for extracting data from Snowflake - PipelineWise compatible"
 authors = ["TransferWise"]
 classifiers=["License :: OSI Approved :: Apache Software License","Programming Language :: Python :: 3 :: Only"]

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -148,6 +148,10 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
                 row_to_persist += (boolean_representation,)
             else:
                 row_to_persist += (elem.hex(),)
+        
+        # orjson is used when writing singer record and it does not recognize Decimal type
+        elif isinstance(elem, Decimal):
+            row_to_persist += (float(elem),)
 
         elif 'boolean' in property_type or property_type == 'boolean':
             if elem is None:
@@ -201,6 +205,7 @@ def row_to_singer_record2(catalog_entry, version, row, columns, time_extracted):
             else:
                 rec[column] = elem.hex()
         
+        # orjson is used when writing singer record and it does not recognize Decimal type
         elif isinstance(elem, Decimal):
             rec[column] = float(elem)
 

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -4,6 +4,7 @@
 import copy
 import datetime
 import time
+from decimal import Decimal
 
 import singer
 import singer.metrics as metrics
@@ -199,6 +200,9 @@ def row_to_singer_record2(catalog_entry, version, row, columns, time_extracted):
                 rec[column] = boolean_representation
             else:
                 rec[column] = elem.hex()
+        
+        elif isinstance(elem, Decimal):
+            rec[column] = float(elem)
 
         elif 'boolean' in property_type or property_type == 'boolean':
             if elem is None:


### PR DESCRIPTION
WP-12820 Snowflake data import failing with DECIMAL (2,1) datatype
https://varicent.atlassian.net/browse/WP-12820

notes: 
- snowflake DECIMAL, NUMERIC types are synonymous with NUMBER
- DECIMAL(x, y):
x: precision - total number of digits allowed
y: scale - number of digits allowed to the right of the decimal point
https://docs.snowflake.com/en/sql-reference/data-types-numeric.html#decimal-numeric