### PR TITLE
fix(WP-29854): add OVERWRITE=TRUE to Snowflake S3 unload to prevent intermittent failures

### DIFF
--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -174,7 +174,7 @@ def generate_copy_sql_external_unload(select_sql, temp_s3_upload_folder, stage_n
 
 def get_common_line_for_unload():
     file_format_line = f"FILE_FORMAT = (TYPE = 'PARQUET')"
-    copy_option_line = f"HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE"
+    copy_option_line = f"HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE OVERWRITE = TRUE"
     return f"{file_format_line} {copy_option_line}"
 
 


### PR DESCRIPTION
Auto-generated by issue investigation pipeline.

Findings: WP-29854_findings_20260320_000609.md

## Summary
- Adds `OVERWRITE = TRUE` to Snowflake `COPY INTO` command options in `get_common_line_for_unload()`
- Prevents intermittent "Files already existing at the unload destination" errors during Snowflake S3 unload imports
- Root cause: leftover parquet files from previously failed import attempts cause subsequent retries to fail

## Test Plan
- [ ] Verify Snowflake S3 unload imports complete successfully
- [ ] Verify retried imports with leftover S3 files no longer fail
- [ ] Run existing tap-snowflake tests to ensure no regressions