### PR TITLE
fix(WP-29854): add OVERWRITE=TRUE to Snowflake COPY INTO S3 unload command

### DIFF
--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -174,7 +174,7 @@ def generate_copy_sql_external_unload(select_sql, temp_s3_upload_folder, stage_n
 
 def get_common_line_for_unload():
     file_format_line = f"FILE_FORMAT = (TYPE = 'PARQUET')"
-    copy_option_line = f"HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE"
+    copy_option_line = f"OVERWRITE = TRUE HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE"
     return f"{file_format_line} {copy_option_line}"
 
 


### PR DESCRIPTION
Auto-generated by issue investigation pipeline.

Findings: WP-29854_findings_20260323_121448.md

## Summary

Adds `OVERWRITE = TRUE` to the Snowflake `COPY INTO` S3 external unload command in `get_common_line_for_unload()`. Without this option, Snowflake refuses to unload if any files already exist at the S3 destination path, causing intermittent import failures when a previous partial attempt left files behind.

## Root Cause

The S3 destination path is deterministic (based on `importID`). If a pod crash or Kubernetes restart interrupts a `COPY INTO` mid-flight, partial Parquet files remain in S3. On retry with the same `importID`, Snowflake sees those files and raises: `Files already existing at the unload destination … Use overwrite option to force unloading.`

## Fix

Single-line change in `tap_snowflake/sync_strategies/common.py`: add `OVERWRITE = TRUE` to the copy option line in `get_common_line_for_unload()`.