### PR TITLE
WP-31834 handle snowflake access denied issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipelinewise-tap-snowflake"
-version = "4.2.0"
+version = "4.3.0"
 description = "Singer.io tap for extracting data from Snowflake - PipelineWise compatible"
 authors = ["TransferWise"]
 classifiers=["License :: OSI Approved :: Apache Software License","Programming Language :: Python :: 3 :: Only"]

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -539,7 +539,8 @@ def do_sync_external_unload(snowflake_conn, catalog_entry, columns, temp_s3_uplo
                         break
                     except snowflake.connector.errors.ProgrammingError as e:
                         err_msg = str(e)
-                        if 'not authorized to perform: s3:ListBucket' in err_msg and i < max_try:
+                        if ('not authorized to perform: s3:ListBucket' in err_msg or
+                                'Failed to access remote file: access denied' in err_msg) and i < max_try:
                             wait = wait_time * i
                             LOGGER.info(f'Attempt {i} failed with error: {err_msg}. Retrying after {wait} seconds')
                             time.sleep(wait)

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -174,7 +174,8 @@ def generate_copy_sql_external_unload(select_sql, temp_s3_upload_folder, stage_n
 
 def get_common_line_for_unload():
     file_format_line = f"FILE_FORMAT = (TYPE = 'PARQUET')"
-    copy_option_line = f"HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE"
+    # OVERWRITE allows container reruns to reuse the same S3 upload folder without failing on leftover unload files.
+    copy_option_line = f"HEADER = TRUE MAX_FILE_SIZE = {128 * 1024 * 1024} DETAILED_OUTPUT = TRUE OVERWRITE = TRUE"
     return f"{file_format_line} {copy_option_line}"
 
 


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-31834?focusedCommentId=837776&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-837776
handling two issues:
- we have been holding the overwrite=true feature for a while, no harm to implement
- Failed to access remote file: access denied could also happen as a hiccup, we should retry under this case as well